### PR TITLE
Fix two minor inconveniences.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,6 @@
     "titleBar.inactiveBackground": "#3178c699",
     "titleBar.inactiveForeground": "#e7e7e799"
   },
-  "peacock.color": "#3178C6"
+  "peacock.color": "#3178C6",
+  "editor.tabSize": 2,
 }

--- a/packages/lingua-franca/gatsby-ssr.js
+++ b/packages/lingua-franca/gatsby-ssr.js
@@ -38,5 +38,5 @@ const CustomColorSwitcherCode = () => {
 }
 
 exports.onRenderBody = ({ setPreBodyComponents }) => {
-  setPreBodyComponents(<CustomColorSwitcherCode />)
+  setPreBodyComponents(<CustomColorSwitcherCode key="colorSwitcherCode"/>)
 }


### PR DESCRIPTION
* The preferred tab size in this repo appears to be 2 spaces.
* I do not know what adding a key property to [gatsby-ssr.js](https://github.com/lf-lang/website-lingua-franca/compare/minor-inconvenience?expand=1#diff-9dfd27dc433cfd042edb3c1e8188682d8e31d45f53c807491b8ff48379b6ea5d) does, except that it makes this error go away:
```
[SITE] Warning: Each child in a list should have a unique "key" prop.
[SITE] 
[SITE] Check the top-level render call using <body>. See
[SITE] https://reactjs.org/link/warning-keys for more information.
[SITE]     at CustomColorSwitcherCode
[SITE]     at HTML (/home/peter/website-lingua-franca/packages/lingua-franca/.cache/pag
[SITE] e-ssr/routes/render-page.js:2621:86)
```