### PR TITLE
Fix to Broken Pull Request Link

### DIFF
--- a/packages/lingua-franca/src/components/handbook/Contributors.tsx
+++ b/packages/lingua-franca/src/components/handbook/Contributors.tsx
@@ -22,7 +22,7 @@ export const Contributors = (props: ContributorsProps) => {
 
   const reposRootURL =
     "https://github.com/lf-lang/website-lingua-franca";
-  const repoPageURL = reposRootURL + "tree/main/" + props.path;
+  const repoPageURL = reposRootURL + "/tree/main" + props.path;
 
   const d = new Date(props.lastEdited);
   const dtf = new Intl.DateTimeFormat(


### PR DESCRIPTION
Issue #42 Hotfix

Should patch up hyperlink between Markdown Files and their associated storage locations on GitHub