### PR TITLE
Adjust syntax for resetting state variables to latest grammar changes

### DIFF
--- a/packages/documentation/copy/en/topics/Modal Models.md
+++ b/packages/documentation/copy/en/topics/Modal Models.md
@@ -104,9 +104,9 @@ Note that *contained* refers to all contents defined locally in the mode and in 
 
 Whenever a mode is entered with a reset transition, the subsequent timing behavior is as if the mode was never executed before.
 If there are state variables that need to be reset or reinitialized, then this can be done in a reaction triggered by `reset` or by marking the state variable for automatic reset (e.g., 
-<span class="lf-c">`state x:int(0) reset`</span>
+<span class="lf-c">`reset state x:int(0)`</span>
 <span class="lf-cpp warning">FIXME</span>
-<span class="lf-py">`state x(0) reset`</span>
+<span class="lf-py">`reset state x(0)`</span>
 <span class="lf-ts warning">FIXME</span>
 <span class="lf-rs warning">FIXME</span>
 ).

--- a/packages/documentation/scripts/linguaFrancaUtils.js
+++ b/packages/documentation/scripts/linguaFrancaUtils.js
@@ -20,7 +20,7 @@ const keywords = [
   "new", 
   "output", 
   "physical", "preamble",
-  "reaction", "reactor", "realtime", 
+  "reaction", "reactor", "realtime", "reset",
   "sec", "secs", "shutdown", "startup", "state",
   "target", "timer", "time", 
   "usec", "usecs", 


### PR DESCRIPTION
Relates to [LF PR #1169](https://github.com/lf-lang/lingua-franca/pull/1169).
Adjusted syntax example.
Also added `reset` to list of keywords.