### PR TITLE
Python methods

### DIFF
--- a/packages/documentation/code/py/src/Methods.lf
+++ b/packages/documentation/code/py/src/Methods.lf
@@ -1,0 +1,15 @@
+target Python
+main reactor Methods {
+    state foo(2)
+    method getFoo() {=
+        return self.foo
+    =}
+    method add(x) {=
+        self.foo += x
+    =}
+    reaction(startup){=
+        print(f"Foo is initialized to {self.getFoo()}.")
+        self.add(40)
+        print(f"2 + 40 = {self.getFoo()}.")
+    =}
+}

--- a/packages/documentation/copy/en/topics/Actions.md
+++ b/packages/documentation/copy/en/topics/Actions.md
@@ -430,7 +430,7 @@ Physical actions are the mechanism for obtaining input from the outside world. B
 
 In the above example, at $startup$, the main reactor creates an external thread that schedules a physical action roughly every 200 msec. The thread uses a built-in function `lf_nanosleep()`, which abstracts platform-specific mechanisms for stalling the thread for a specified amount of time. The thread is created with a built-in function `lf_thread_create()`, which similarly abstracts platform-specific mechanisms for creating threads.
 
-The code executed by the thread is defined in a $preamble$ section. See [Preambles and Methods](/docs/handbook/preambles-and-methods).
+The code executed by the thread is defined in a $preamble$ section. See [Preambles](/docs/handbook/preambles).
 
 **Important Note:** Asynchronous calls to `lf_schedule()` will not work if you set the [`threading` target parameter](/docs/handbook/target-declaration#threading) to `false`. You must use a threaded runtime for such asynchronous calls to work correctly.
 

--- a/packages/documentation/copy/en/topics/Actions.md
+++ b/packages/documentation/copy/en/topics/Actions.md
@@ -303,7 +303,7 @@ main reactor {
     =}
     state thread_id:lf_thread_t(0);
     physical action a(100 msec):int;
-
+  
     reaction(startup) -> a {=
         // Start a thread to schedule physical actions.
         lf_thread_create(&self->thread_id, &external, a);
@@ -326,7 +326,7 @@ main reactor {
 
     state thread: std::thread;
     physical action a:int;
-
+  
     reaction(startup) -> a {=
         // Start a thread to schedule physical actions.
         thread = std::thread([&]{
@@ -361,7 +361,7 @@ main reactor {
     =}
     state thread;
     physical action a(100 msec);
-
+  
     reaction(startup) -> a {=
         # Start a thread to schedule physical actions.
         self.thread = self.threading.Thread(target=self.external, args=(a,))
@@ -381,7 +381,7 @@ target TypeScript
 main reactor {
 
     physical action a(100 msec):number;
-
+  
     reaction(startup) -> a {=
         // Have asynchronous callback schedule physical action.
         setTimeout(() => {

--- a/packages/documentation/copy/en/topics/Distributed Execution.md
+++ b/packages/documentation/copy/en/topics/Distributed Execution.md
@@ -71,7 +71,7 @@ federated reactor {
     p = new Print();
     c.out -> p.in;
 }
-
+ 
 ```
 
 ```lf-cpp
@@ -105,7 +105,7 @@ federated reactor {
     p = new Print();
     c.out -> p.inp;
 }
-
+ 
 ```
 
 ```lf-ts
@@ -348,7 +348,7 @@ import Count, Print from "Federated.lf"
 reactor PrintTimer extends Print {
     timer t(0, 1 sec);
     reaction(t) {=
-        lf_print("Timer ticked at (%lld, %d).",
+        lf_print("Timer ticked at (%lld, %d).", 
             lf_time_logical_elapsed(), lf_tag().microstep
         );
     =}
@@ -414,7 +414,7 @@ import Count, Print from "Federated.lf"
 reactor PrintTimer(STP_offset:time(10 msec)) extends Print {
     timer t(0, 1 sec);
     reaction(t) {=
-        lf_print("Timer ticked at (%lld, %d).",
+        lf_print("Timer ticked at (%lld, %d).", 
             lf_time_logical_elapsed(), lf_tag().microstep
         );
     =}
@@ -501,7 +501,7 @@ reactor PrintTimer {
         );
     =}
     reaction(t) {=
-        lf_print("Timer ticked at (%lld, %d).",
+        lf_print("Timer ticked at (%lld, %d).", 
             lf_time_logical_elapsed(), lf_tag().microstep
         );
     =}

--- a/packages/documentation/copy/en/topics/Inputs and Outputs.md
+++ b/packages/documentation/copy/en/topics/Inputs and Outputs.md
@@ -145,7 +145,7 @@ reactor Destination {
             sum += *y.get();
         }
 
-        std::cout << "Received: " << sum << std::endl;
+        std::cout << "Received: " << sum << std::endl; 
     =}
 }
 

--- a/packages/documentation/copy/en/topics/Preambles.md
+++ b/packages/documentation/copy/en/topics/Preambles.md
@@ -1,8 +1,8 @@
 ---
-title: "Preambles and Methods"
+title: "Preambles"
 layout: docs
-permalink: /docs/handbook/preambles-and-methods
-oneline: "Defining functions and methods in Lingua Franca."
+permalink: /docs/handbook/preambles
+oneline: "Defining preambles in Lingua Franca."
 preamble: >
 ---
 
@@ -148,7 +148,7 @@ An example of this can be found in [PreambleFile.lf](https://github.com/lf-lang/
 Admittedly, the precise interactions of preambles and imports can become confusing. The preamble mechanism will likely be refined in future revisions.
 
 Note that functions defined in the preamble cannot access members such as state variables of the reactor unless they are explicitly passed as arguments.
-If access to the inner state of a reactor is required, [methods](#Methods) present a viable and easy to use alternative.
+If access to the inner state of a reactor is required, [methods](/docs/handbook/reactions-and-methods#method-declaration) present a viable and easy to use alternative.
 
 </div>
 
@@ -299,50 +299,5 @@ The important takeaway here is with the package.json file and the compiled JavaS
 <div class="lf-rs warning">
 
 FIXME: Add $preamble$ example.
-
-</div>
-
-## Methods
-
-<div class="lf-c lf-py lf-ts lf-rs">
-
-Methods are not currently implemented in the $target-language$ target.
-
-</div>
-
-<div class="lf-cpp">
-
-### Using Methods
-
-Sometimes reactors need to perform certain operations on state variables and/or parameters that are shared between reactions or that are too complex to
-be implemented in a single reaction. In such cases, methods can be defined within reactors to facilitate code reuse and enable a better structuring of the
-reactor's functionality. Analogous to class methods, methods in LF can access all state variables and parameters, and can be invoked from all reaction
-bodies or from other methods. Consdider the [Method](https://github.com/lf-lang/lingua-franca/blob/master/test/Cpp/src/target/Methods.lf) example:
-
-```lf-cpp
-main reactor {
-    state foo:int(2);
-
-    const method get_foo(): int {=
-        return foo;
-    =}
-
-    method add(x:int) {=
-        foo += x;
-    =}
-
-    reaction(startup){=
-        std::cout << "Foo is initialized to " << get_foo() << std::endl;
-        add(40);
-        std::cout << "2 + 40 = " << get_foo() << std::endl;
-    =}
-}
-```
-
-This reactor defines two methods `get_foo` and `add`. `get_foo` is quailfied as a const method, which indicates that it has read-only access to the
-state variables. This is direclty translated to a C++ const method in the code generation process. `get_foo` receives no arguments and returns an integer
-(`int`) indicating the current value of the `foo` state variable. `add` returns nothing (`void`) and receives one interger argument, which it uses to
-increment `foo`. Both methods are visible in all reactions of the reactor. In this example, the reactio to startup calles both methods in order ro read
-and modify its state.
 
 </div>

--- a/packages/documentation/copy/en/topics/Reactions and Methods.md
+++ b/packages/documentation/copy/en/topics/Reactions and Methods.md
@@ -317,13 +317,13 @@ This instantiates the above `Overwriting` reactor and monitors its outputs.
 
 ## Method Declaration
 
-<div class="lf-py lf-ts lf-rs">
+<div class="lf-ts lf-rs">
 
 The $target-language$ target does not currently support methods.
 
 </div>
 
-<div class="lf-cpp lf-c">
+<div class="lf-cpp lf-c lf-py">
 
 A method declaration has one of the forms:
 
@@ -385,7 +385,22 @@ main reactor Methods {
 ```
 
 ```lf-py
-WARNING: No source file found: ../code/py/src/Methods.lf
+target Python
+main reactor Methods {
+    state foo(2)
+    method getFoo() {=
+        return self.foo
+    =}
+    method add(x) {=
+        self.foo += x
+    =}
+    reaction(startup){=
+        print(f"Foo is initialized to {self.getFoo()}.")
+        self.add(40)
+        print(f"2 + 40 = {self.getFoo()}.")
+    =}
+}
+
 ```
 
 ```lf-ts
@@ -398,6 +413,20 @@ WARNING: No source file found: ../code/rs/src/Methods.lf
 
 $end(Methods)$
 
-This reactor defines two methods `getFoo` and `add`. <span class="lf_cpp">`getFoo` is qualified as a const method, which indicates that it has read-only access to the state variables. This is direclty translated to a C++ const method in the code generation process.</span> The `getFoo` method receives no arguments and returns an integer (`int`) indicating the current value of the `foo` state variable. The `add` method returns nothing (`void`) and receives one interger argument, which it uses to increment `foo`. Both methods are visible in all reactions of the reactor. In this example, the reaction to startup calls both methods in order to read and modify its state.
+This reactor defines two methods `getFoo` and `add`.
+<span class="lf-cpp">
+`getFoo` is qualified as a const method, which indicates that it has read-only
+access to the state variables. This is direclty translated to a C++ const method
+in the code generation process.
+</span>
+The `getFoo` method receives no arguments and returns an integer (`int`)
+indicating the current value of the `foo` state variable. The `add` method
+returns nothing
+<span class="lf-cpp lf-c">
+(`void`)
+</span>
+and receives one interger argument, which it uses to increment `foo`. Both
+methods are visible in all reactions of the reactor. In this example, the
+reaction to startup calls both methods in order to read and modify its state.
 
 </div>

--- a/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
+++ b/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
@@ -55,7 +55,7 @@ const handbookPages = [
       { file: "topics/Modal Models.md" },
       { file: "topics/Deadlines.md" },
       { file: "topics/Multiports and Banks.md" },
-      { file: "topics/Preambles and Methods.md" },
+      { file: "topics/Preambles.md" },
       { file: "topics/Distributed Execution.md" },
       { file: "topics/Termination.md" },
     ],

--- a/packages/lingua-franca/src/lib/documentationNavigation.ts
+++ b/packages/lingua-franca/src/lib/documentationNavigation.ts
@@ -132,10 +132,10 @@ export function getDocumentationNavForLanguage(
           oneline: "Multiports and Banks of Reactors.",
         },
         {
-          title: "Preambles and Methods",
-          id: "1-preambles-and-methods",
-          permalink: "/docs/handbook/preambles-and-methods",
-          oneline: "Defining functions and methods in Lingua Franca.",
+          title: "Preambles",
+          id: "1-preambles",
+          permalink: "/docs/handbook/preambles",
+          oneline: "Defining preambles in Lingua Franca.",
         },
         {
           title: "Distributed Execution",


### PR DESCRIPTION
This removes a redundant explanation for methods and adds the example for methods in the Python target.