### PR TITLE
Attempt to fix #90 (target selector broken).

### DIFF
--- a/packages/lingua-franca/gatsby-browser.js
+++ b/packages/lingua-franca/gatsby-browser.js
@@ -1,6 +1,7 @@
 // This hooks ups client-side app analytics
 // it's based on how the google analytics plugin works for gatsby
 // https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-google-analytics/src/gatsby-browser.js
+setInitialTargetLanguage = require("./src/lib/setInitialTargetLanguage")
 
 exports.onRouteUpdate = ({ location, prevLocation }) => {
   // Run both clear and app insights for a bit, then drop app insights
@@ -11,6 +12,7 @@ exports.onRouteUpdate = ({ location, prevLocation }) => {
   //       t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
   //       y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
   //   })(window, document, "clarity", "script", "3w5kyel345");
+  setInitialTargetLanguage.setInitialTargetLanguage()
 
   var sdkInstance = "appInsightsSDK"
   window[sdkInstance] = "appInsights"

--- a/packages/lingua-franca/src/components/layout/Sidebar.tsx
+++ b/packages/lingua-franca/src/components/layout/Sidebar.tsx
@@ -144,11 +144,6 @@ export const Sidebar = (props: Props) => {
     >
       {props.children}
     </div>
-    useEffect(() => {
-      const hidden: boolean = props.target === (getTargetLanguage() || setInitialTargetLanguage())
-      const retWritable = document.getElementById(id)
-      if (retWritable) retWritable.style.display = hidden ? "" : "none"
-    }, [ret])
     return ret;
   }
 
@@ -160,12 +155,6 @@ export const Sidebar = (props: Props) => {
 
   /* Target language chooser */
   const RenderTargetChooser = () => {
-    useEffect(() => {
-      return globalHistory.listen(({ action }) => {
-        if (action === "PUSH") setInitialTargetLanguage()
-      })
-    }, [setInitialTargetLanguage])
-
     return (
       <li id="targetChooser" className="closed" onClick={toggleOpen}>
         <button id="targetSelector">

--- a/packages/lingua-franca/src/lib/setInitialTargetLanguage.ts
+++ b/packages/lingua-franca/src/lib/setInitialTargetLanguage.ts
@@ -7,9 +7,6 @@ export const setInitialTargetLanguage = () => {
   const target:string = getTargetLanguage()
       || (hasLocalStorage && localStorage.getItem("last-selected-target-language"))
       || defaultTargetLanguage;
-
-  let selector = document.getElementById("targetSelector") as any;
-  if (selector != null) selector.value = target;
   setTargetLanguage(target);
   return target;
 }

--- a/packages/lingua-franca/src/templates/documentation.tsx
+++ b/packages/lingua-franca/src/templates/documentation.tsx
@@ -94,7 +94,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
   const slug = slugger()
   return (
     <Layout title={`${prefix} - ${post.frontmatter.title}`} description={post.frontmatter.oneline || ""} lang={props.pageContext.lang}>
-      <section id="doc-layout" onLoad={ () => setInitialTargetLanguage() }>
+      <section id="doc-layout">
         <SidebarToggleButton />
 
         <div className="page-popup" id="page-helpful-popup" style={{ opacity: 0 }}>


### PR DESCRIPTION
I cannot verify that this solution works because I could not reproduce the original issue.

This PR will result in an (in some cases useless) query string being appended to the URL of every page, including those without the target-specific class labels (e.g., `lf-c`). I am not sure if anyone cares about that.